### PR TITLE
Remove dependency from expath-pkg.xml

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://www.edirom.de/apps/EditionExample" abbrev="EditionExample" version="0.1" spec="1.0">
     <title>Edition Example</title>
-    <dependency package="http://exist-db.org/apps/shared"/>
 </package>


### PR DESCRIPTION
## Description, Context and related Issue
This dependency blocked the automatic deployment (xar in autodeploy directory during database startup) of the EditionExample in eXist-db. The manual deployment worked with it, and still works without. The automatic deployment works only without the dependency
