### PR TITLE
add a TEI file with style and rendition examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *.DS_Store
 .existdb.json
 dist/*
+.idea/

--- a/content/ediromEditions/edirom_edition_example.xml
+++ b/content/ediromEditions/edirom_edition_example.xml
@@ -29,6 +29,12 @@
                             <name xml:lang="en">preface</name>
                         </names>
                     </navigatorItem>
+                    <navigatorItem xml:id="navItem-0-3" sortNo="3" targets="xmldb:exist:///db/apps/edirom/edition-example/content/texts/tei-test.xml">
+                        <names>
+                            <name xml:lang="de">TEI Testdatei</name>
+                            <name xml:lang="en">TEI test file</name>
+                        </names>
+                    </navigatorItem>
                 </navigatorCategory>
                 <navigatorCategory xml:id="navCategory-1" sortNo="2">
                     <names>

--- a/content/texts/tei-test.xml
+++ b/content/texts/tei-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/Vault/P5/4.9.0/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/Vault/P5/4.9.0/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+        schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>TEI Test File for the Edirom</title>
+            </titleStmt>
+            <publicationStmt>
+                <p>Publicly available under a CC0 license</p>
+            </publicationStmt>
+            <sourceDesc>
+                <p>Born digital</p>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <tagsDecl>
+                <rendition xml:id="ab">border: 1px solid blue</rendition>
+            </tagsDecl>
+        </encodingDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <p style="border:1px solid red">This text should appear with a red border due to its <code>style</code> attribute.</p>
+            <ab rendition="#ab">This text should appear with a blue border due to its <code>rendition</code> attribute</ab>
+            <p>For more information regarding styling of TEI files see <ptr target="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ST.html#STGAre"/>.</p>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Added a TEI file with style and rendition examples, and added a link to the navigation

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Built the Edition example locally via `ant` and dropped the xar file into the current Edirom Online dev version.
Tested this locally and it kinda works:
<img width="930" height="419" alt="Bildschirmfoto 2026-02-12 um 11 51 36" src="https://github.com/user-attachments/assets/49f7c312-5657-43d6-9969-e6894218dea0" />

Kinda, because the rendition-version does not work as expected. Off the top of my head that might be due to the fact that the Edirom does not send the whole TEI file to the XSLT transformer but only the body section. Yet, the needed `<rendition>` elements are found in the TEI Header.
