### PR TITLE
[bug] search not working

### DIFF
--- a/collection.xconf
+++ b/collection.xconf
@@ -1,17 +1,35 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
-    <index xmlns:tei="http://www.tei-c.org/ns/1.0">
+    <index xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mei="http://www.music-encoding.org/ns/mei">
 <!--         Full text index based on Lucene -->
         <lucene>
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
             <analyzer id="ws" class="org.apache.lucene.analysis.core.WhitespaceAnalyzer"/>
-            <text qname="tei:title" boost="2.0"/>
             <text qname="@type" analyzer="ws"/>
             <text qname="@key" analyzer="ws"/>
-            <text qname="tei:persName" boost="2.0"/>
-            <text qname="tei:orgName" boost="2.0"/>
-            <text qname="tei:settlement" boost="2.0"/>
             
-        </lucene>
+            <!--TEI-->
+            <text qname="tei:orgName" boost="2.0"/>
+            <text qname="tei:persName" boost="2.0"/>
+            <text qname="tei:settlement" boost="2.0"/>
+            <text qname="tei:text"/>
+            <text qname="tei:title" boost="2.0"/>
+            
+            <!--MEI-->
+            <text qname="mei:mei">
+                <ignore qname="mei:music"/>
+                <ignore qname="mei:title"/>
+                <ignore qname="mei:annot"/>
+            </text>
+            <text qname="mei:title" boost="2.0"/>
+            <text qname="mei:annot"/>
+            
+            <!--  HTML documents with XHTML namespace -->
+            <text qname="html:body" xmlns:html="http://www.w3.org/1999/xhtml"/>
+            <text qname="html:title" boost="2.0" xmlns:html="http://www.w3.org/1999/xhtml"/>
+            <!--  HTML documents without namespace (DOCTYPE html) -->
+            <text qname="body"/>
+            <text qname="title" boost="2.0"/>
+                    </lucene>
         
         <!-- Range indexes -->
         <range>


### PR DESCRIPTION
## Description, Context and related Issue
The search was not working. Since the Klarinettenquintett has a working search, its _collection.xconf_ was consulted and adapted for `MEI`. `html` was added newly. 

**Note:**

This did not seem to solve the whole problem. Since Klarinettenquintett has its annotation text in `annot` elements in the source file (source-4-MEI.xml), the EditionExampe (and most other Edirom Editions) capture their annotations in the work file and `work` element.  See https://github.com/Edirom/Edirom-Online-Backend/issues/167 so the whole picture only works with this PR and the PR in the backend. 

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #35 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)



