### PR TITLE
Remove wrong link to source description

### DIFF
--- a/content/editions/edirom_edition_7bade454-c1b2-499f-8100-7b3e369e2d65.xml
+++ b/content/editions/edirom_edition_7bade454-c1b2-499f-8100-7b3e369e2d65.xml
@@ -67,9 +67,7 @@
             <langUsage>
                 <language auth="de"/>
             </langUsage>
-            <notesStmt>
-                 <annot type="descLink" plist="xmldb:exist:///db/apps/edirom/edition-example/content/editions/edirom_edition_7bade454-c1b2-499f-8100-7b3e369e2d65.xml"/>
-            </notesStmt>
+            <notesStmt></notesStmt>
             <classification>
                <termList>
                   <term type="source">edition</term>

--- a/content/sources/edirom_source_2b2b26e5-c85d-4edd-8806-fe126ce390a2.xml
+++ b/content/sources/edirom_source_2b2b26e5-c85d-4edd-8806-fe126ce390a2.xml
@@ -30,7 +30,6 @@
             </titleStmt>
                <pubStmt/>
                <notesStmt>
-                  <annot type="descLink" plist="xmldb:exist:///db/apps/edirom/edition-example/content/sources/edirom_source_2b2b26e5-c85d-4edd-8806-fe126ce390a2.xml"/>
                   <annot plist="#overlay_1_1" type="overlay" xml:id="overlay_1">
                   <title>sample SVG overlay</title>
                </annot>

--- a/content/sources/edirom_source_47dde5ab-b8ff-4004-bfde-b65ea5a9a15e.xml
+++ b/content/sources/edirom_source_47dde5ab-b8ff-4004-bfde-b65ea5a9a15e.xml
@@ -28,9 +28,7 @@
                <title>Autograph</title>
             </titleStmt>
             <pubStmt/>
-            <notesStmt>
-                <annot type="descLink" plist="xmldb:exist:///db/apps/edirom/edition-example/content/works/edirom_source_47dde5ab-b8ff-4004-bfde-b65ea5a9a15e.xml"/>
-            </notesStmt>
+            <notesStmt></notesStmt>
             <relationList>
                <relation rel="isEmbodimentOf"
                          target="xmldb:exist:///db/apps/edirom/edition-example/content/works/edirom_work_291f7ad8-9bb8-45eb-9186-801dec2f80d9.xml#edirom_work_291f7ad8-9bb8-45eb-9186-801dec2f80d9_exp1"

--- a/content/works/edirom_work_291f7ad8-9bb8-45eb-9186-801dec2f80d9.xml
+++ b/content/works/edirom_work_291f7ad8-9bb8-45eb-9186-801dec2f80d9.xml
@@ -185,9 +185,7 @@
                     <title>Werkdatei zu Trüber Abschied</title>
                 </titleStmt>
                 <pubStmt/>
-                <notesStmt>
-                    <annot type="descLink" plist="xmldb:exist:///db/apps/edirom/edition-example/content/works/edirom_work_291f7ad8-9bb8-45eb-9186-801dec2f80d9.xml"/>
-                </notesStmt>
+                <notesStmt></notesStmt>
             </manifestation>
         </manifestationList>
     </meiHead>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
I remove wrong links to source descriptions that are self-pointing to the source instead than to a tei file.
This makes the source description disappear from getLinkTarget and from the frontend. Before, a black screen appeared.

It might be better to create demo source description tei files for some of the sources instead.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #43 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with the develop branch of Frontend and Backend

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

