### PR TITLE
fixes issue #237 from in the edirom-frontend repo

### DIFF
--- a/prefs.xml
+++ b/prefs.xml
@@ -29,5 +29,6 @@
         <entry key="image_prefix" value=""/>
         <!-- <entry key="edition_path" value="/db/apps/edirom/edition-example/content/ediromEditions/"/> -->
         <entry key="edition_path" value="/db/apps/edirom/edition-example/content/"/>
+        <entry key="additional_css_path" value="xmldb:exist:///db/apps/edirom/edition-example/resources/css/text-style.css"/>
     </entries>
 </prefs>

--- a/resources/css/text-style.css
+++ b/resources/css/text-style.css
@@ -1,0 +1,116 @@
+/* text styling for emeritus edition */
+
+/* text blocks and heading */
+.textViewContent {
+    margin-right: 3em;
+    margin-left: 3em;
+}
+
+
+.textViewContent .teidiv0 > h2 {
+    margin-bottom: 0.5em!important;
+}
+
+.textViewContent h3 {
+    margin-top:unset!important;
+}
+
+.textViewContent h1, .textViewContent .teidiv0 h2, .textViewContent h3, .textViewContent h4 {
+    margin-left:0px;
+    text-align: left;
+    width: 100%;
+}
+
+div.textViewContent div.simple section.teidiv0 p,
+div.textViewContent div.simple div.teidiv0 p {
+    margin-left: 0px!important;
+}
+
+
+/* Definition Lists rendered as tables */
+dl {
+    padding: 0px;
+    width: 100%;
+    margin: 0px;
+    overflow:auto;
+    display: grid;
+    grid-template-columns: minmax(80px, max-content) auto;
+}
+
+dt {
+    padding-left:2em;
+    word-wrap:break-word;
+}
+
+section.teidiv0,
+div.teidiv0 {
+    margin-bottom: 2em;
+}
+
+div.teidiv1 {
+    margin-bottom: 2em;
+    /*padding-right: 8%;*/
+}
+
+div.teidiv1 > p {
+    /*padding-left: 8%;*/
+}
+
+figure.figure,
+div.figure {
+   display: grid;
+   align-items: center;
+   justify-content: center;
+   width:80%;
+   padding:1em;
+   margin:auto;
+}
+
+figure.figure img,
+div.figure img {
+    max-width:100%;
+    max-height:100%;
+    margin:auto;
+}
+
+/* special styling at "Werkgenese" */
+
+.citquote {
+    padding-bottom: 1em;
+    margin-right: 3em;
+    margin-left: 3em;
+}
+
+.caption {
+    margin-top: 1em;
+    font-size: smaller;
+}
+
+span.bold {
+    font-weight: bold;
+}
+
+span.italic {
+    font-style: italic;
+}
+
+span.underline1 {
+    text-decoration-line: underline;
+}
+
+span.typewriter {
+    font-family: 'Lucida Sans Unicode', Arial;
+}
+
+span.superscript {
+    vertical-align: super!important;
+}
+
+span.subscript {
+    vertical-align: sub!important;
+}
+
+span.musical-symbol {
+    font-family: Bravura;
+    font-size: 1.6em;
+}


### PR DESCRIPTION
## Description, Context and related Issue
The Help/text window in the Edition Example rendered "wobbly": long lines did not
break at the right border, and the indentation/layout shifted when clicking a TOC
link. The Weber Klarinettenquintett edition did not show this because it ships its
own text CSS and registers it via `additional_css_path`, which masks the frontend's
default `.textViewContent` behavior.

This PR fixes the Edition Example by adding the missing text stylesheet and
registering it:
- Added `resources/css/text-style.css` (side margins, `word-wrap: break-word`,
  width constraints for `.textViewContent`, `dl`/`dt`, figures, and inline spans),
  mirroring the Klarinettenquintett edition.
- Added an `additional_css_path` entry in `prefs.xml` pointing to
  `xmldb:exist:///db/apps/edirom/edition-example/resources/css/text-style.css`.

This addresses the Edition-side cause of the wobble reported in the frontend issue
Edirom/Edirom-Online-Frontend#237.

Refs #46
Refs Edirom/Edirom-Online-Frontend#237

## How Has This Been Tested?
- Deployed the Edition Example and opened text documents in the Help/text window
  (preface / "Vorwort" and the TEI test file).
- Verified long lines now wrap at the right border and no longer overflow.
- Verified indentation/layout stays stable when clicking TOC links.
- Checked in Chrome and Firefox (macOS).

## Types of changes
- Bug fix (non-breaking change which fixes an issue)